### PR TITLE
Добавлен .coveragerc

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,2 @@
+[run]
+omit = tests/*


### PR DESCRIPTION
Добавлен .coveregerc для корректного отображения покрытия тестами.